### PR TITLE
note zero hash on ecrecover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/src/precompiles/ecrecover.rs
+++ b/src/precompiles/ecrecover.rs
@@ -247,6 +247,10 @@ pub fn ecrecover_inner(
     digest: [u8; 32],
     serialized_signature: Vec<u8>,
 ) -> Result<VerifyingKey, ()> {
+    if digest.iter().all(|el| *el == 0) {
+        // zero hash is not supported by our convension at the current version, will be activated later separately
+        return Err(());
+    }
     // we expect pre-validation, so this check always works
     let sig =
         k256::ecdsa::recoverable::Signature::try_from(&serialized_signature[..]).map_err(|_| ())?;


### PR DESCRIPTION
# What ❔

Version 1.4.0 of deployment will not support activation of 0 as message hash of ECRECOVER. It'll be activated separately in 1.4.1

## Why ❔

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
