### PR TITLE
Adapt for new SHA3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "sb-1-4-1-with-updated-deps" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "sb-1-4-1-with-updated-deps" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -271,6 +271,7 @@ struct CoreWrapper {
 
 struct Keccak256VarCore {
     state: Keccak256InnerState,
+    _round_count: usize
 }
 
 static_assertions::assert_eq_size!(Keccak256, CoreWrapper);


### PR DESCRIPTION
# What ❔

Make sure that abstractions continue to work with new sha3 library

Requires the following PR to be merged: https://github.com/matter-labs/era-zkevm_opcode_defs/pull/18

## Why ❔

For server compatibility.


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
