### PR TITLE
Update crypto dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "av_bump_dependencies" }
+
 
 [dev-dependencies]
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "av_bump_dependencies" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1" }
 
 
 [dev-dependencies]

--- a/src/precompiles/ecrecover.rs
+++ b/src/precompiles/ecrecover.rs
@@ -142,11 +142,6 @@ impl<const B: bool> Precompile for ECRecoverPrecompile<B> {
         let v = buffer[31];
         assert!(v == 0 || v == 1);
 
-        let mut serialized = Vec::with_capacity(65);
-        serialized.extend(r_bytes);
-        serialized.extend(s_bytes);
-        serialized.push(v);
-
         let pk = ecrecover_inner(&hash, &r_bytes, &s_bytes, v);
 
         // here it may be possible to have non-recoverable k*G point, so can fail

--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -259,18 +259,19 @@ pub fn keccak256_rounds_function<M: Memory, const B: bool>(
 
 pub type Keccak256InnerState = [u64; 25];
 
+struct Sha3State {
+    state: [u64; 25],
+    _round_count: usize,
+}
+
 struct BlockBuffer {
     _buffer: [u8; 136],
     _pos: u8,
 }
 
 struct CoreWrapper {
-    core: Keccak256VarCore,
+    core: Sha3State,
     _buffer: BlockBuffer,
-}
-
-struct Keccak256VarCore {
-    state: Keccak256InnerState,
 }
 
 static_assertions::assert_eq_size!(Keccak256, CoreWrapper);


### PR DESCRIPTION
# What ❔

Ported commit from the v1.5.0 to v1.4.1

## Why ❔

To make it work after updating era-zkevm_opcode_defs. Should be merged after https://github.com/matter-labs/era-zkevm_opcode_defs/pull/19.
It's required by zksync-era

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
