### PR TITLE
Remove static assertions dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
-static_assertions = "1"
 
 zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.5.0" }
 # zkevm_opcode_defs = { path = "../era-zkevm_opcode_defs" }

--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -274,8 +274,6 @@ struct CoreWrapper {
     _buffer: BlockBuffer,
 }
 
-static_assertions::assert_eq_size!(Keccak256, CoreWrapper);
-
 pub fn transmute_state(reference_state: Keccak256) -> Keccak256InnerState {
     // we use a trick that size of both structures is the same, and even though we do not know a stable field layout,
     // we can replicate it

--- a/src/precompiles/sha256.rs
+++ b/src/precompiles/sha256.rs
@@ -180,8 +180,6 @@ struct Sha256VarCore {
     _block_len: u64,
 }
 
-static_assertions::assert_eq_size!(Sha256, CoreWrapper);
-
 pub fn transmute_state(reference_state: Sha256) -> Sha256InnerState {
     // we use a trick that size of both structures is the same, and even though we do not know a stable field layout,
     // we can replicate it


### PR DESCRIPTION
# Remove static assertion library dependency

The library was used to assert that things that the types that are transmuted are of equal size but `std::mem::transmute` checks that anyway.