### PR TITLE
Revert to making heap read in keccak precompile

### DIFF
--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -162,7 +162,7 @@ impl<const B: bool> Precompile for Keccak256Precompile<B> {
                     let data_query = MemoryQuery {
                         timestamp: timestamp_to_read,
                         location: MemoryLocation {
-                            memory_type: MemoryType::FatPointer,
+                            memory_type: MemoryType::Heap,
                             page: MemoryPage(source_memory_page),
                             index: MemoryIndex(memory_index as u32),
                         },


### PR DESCRIPTION
# What ❔

Revert to making heap read in keccak precompile.

## Why ❔

Using a fat pointer here causes a panic

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
