### PR TITLE
v1.5.0 Precompiles return number of cycles used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1", features = ["derive"] }
+num_enum = "0.6"
 
 zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.5.0" }
 # zkevm_opcode_defs = { path = "../era-zkevm_opcode_defs" }

--- a/src/precompiles/ecrecover.rs
+++ b/src/precompiles/ecrecover.rs
@@ -26,7 +26,12 @@ impl<const B: bool> Precompile for ECRecoverPrecompile<B> {
         monotonic_cycle_counter: u32,
         query: LogQuery,
         memory: &mut M,
-    ) -> Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)> {
+    ) -> (
+        usize,
+        Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)>,
+    ) {
+        const NUM_ROUNDS: usize = 1;
+
         // read the parameters
         let precompile_call_params = query;
         let params = precompile_abi_in_log(precompile_call_params);
@@ -230,11 +235,13 @@ impl<const B: bool> Precompile for ECRecoverPrecompile<B> {
             }
         }
 
-        if B {
+        let witness = if B {
             Some((read_history, write_history, vec![round_witness]))
         } else {
             None
-        }
+        };
+
+        (NUM_ROUNDS, witness)
     }
 }
 
@@ -261,11 +268,14 @@ pub fn ecrecover_function<M: Memory, const B: bool>(
     monotonic_cycle_counter: u32,
     precompile_call_params: LogQuery,
     memory: &mut M,
-) -> Option<(
-    Vec<MemoryQuery>,
-    Vec<MemoryQuery>,
-    Vec<ECRecoverRoundWitness>,
-)> {
+) -> (
+    usize,
+    Option<(
+        Vec<MemoryQuery>,
+        Vec<MemoryQuery>,
+        Vec<ECRecoverRoundWitness>,
+    )>,
+) {
     let mut processor = ECRecoverPrecompile::<B>;
     processor.execute_precompile(monotonic_cycle_counter, precompile_call_params, memory)
 }

--- a/src/precompiles/secp256r1_verify.rs
+++ b/src/precompiles/secp256r1_verify.rs
@@ -24,7 +24,12 @@ impl<const B: bool> Precompile for Secp256r1VerifyPrecompile<B> {
         monotonic_cycle_counter: u32,
         query: LogQuery,
         memory: &mut M,
-    ) -> Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)> {
+    ) -> (
+        usize,
+        Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)>,
+    ) {
+        const NUM_ROUNDS: usize = 1;
+
         // read the parameters
         let precompile_call_params = query;
         let params = precompile_abi_in_log(precompile_call_params);
@@ -237,11 +242,13 @@ impl<const B: bool> Precompile for Secp256r1VerifyPrecompile<B> {
             }
         }
 
-        if B {
+        let witness = if B {
             Some((read_history, write_history, vec![round_witness]))
         } else {
             None
-        }
+        };
+
+        (NUM_ROUNDS, witness)
     }
 }
 
@@ -288,11 +295,14 @@ pub fn secp256r1_verify_function<M: Memory, const B: bool>(
     monotonic_cycle_counter: u32,
     precompile_call_params: LogQuery,
     memory: &mut M,
-) -> Option<(
-    Vec<MemoryQuery>,
-    Vec<MemoryQuery>,
-    Vec<Secp256r1VerifyRoundWitness>,
-)> {
+) -> (
+    usize,
+    Option<(
+        Vec<MemoryQuery>,
+        Vec<MemoryQuery>,
+        Vec<Secp256r1VerifyRoundWitness>,
+    )>,
+) {
     let mut processor = Secp256r1VerifyPrecompile::<B>;
     processor.execute_precompile(monotonic_cycle_counter, precompile_call_params, memory)
 }

--- a/src/precompiles/sha256.rs
+++ b/src/precompiles/sha256.rs
@@ -33,7 +33,10 @@ impl<const B: bool> Precompile for Sha256Precompile<B> {
         monotonic_cycle_counter: u32,
         query: LogQuery,
         memory: &mut M,
-    ) -> Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)> {
+    ) -> (
+        usize,
+        Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)>,
+    ) {
         let precompile_call_params = query;
         let params = precompile_abi_in_log(precompile_call_params);
         let timestamp_to_read = precompile_call_params.timestamp;
@@ -146,11 +149,13 @@ impl<const B: bool> Precompile for Sha256Precompile<B> {
             }
         }
 
-        if B {
+        let witness = if B {
             Some((read_queries, write_queries, witness))
         } else {
             None
-        }
+        };
+
+        (num_rounds, witness)
     }
 }
 
@@ -158,7 +163,10 @@ pub fn sha256_rounds_function<M: Memory, const B: bool>(
     monotonic_cycle_counter: u32,
     precompile_call_params: LogQuery,
     memory: &mut M,
-) -> Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Sha256RoundWitness>)> {
+) -> (
+    usize,
+    Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Sha256RoundWitness>)>,
+) {
     let mut processor = Sha256Precompile::<B>;
     processor.execute_precompile(monotonic_cycle_counter, precompile_call_params, memory)
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -185,7 +185,8 @@ pub trait DecommittmentProcessor: std::fmt::Debug {
 pub trait Precompile: std::fmt::Debug {
     type CycleWitness: Clone + std::fmt::Debug;
 
-    /// execute a precompile by using request and access to memory. May be output
+    /// Execute a precompile by using request and access to memory. Output number of cycles needed.
+    /// May be output
     /// - all memory reads (may be removed later on)
     /// - all memory writes (depending on the implementation we may directly write to `memory` and also remove it)
     /// - FSM cycle witness parameters
@@ -194,7 +195,10 @@ pub trait Precompile: std::fmt::Debug {
         monotonic_cycle_counter: u32,
         query: LogQuery,
         memory: &mut M,
-    ) -> Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)>;
+    ) -> (
+        usize,
+        Option<(Vec<MemoryQuery>, Vec<MemoryQuery>, Vec<Self::CycleWitness>)>,
+    );
 }
 
 pub enum SpongeExecutionMarker {


### PR DESCRIPTION
Precompiles now return number of cycles used. Also, adds an enum of precompile addresses