### PR TITLE
fix unneeded reads

### DIFF
--- a/src/precompiles/keccak256.rs
+++ b/src/precompiles/keccak256.rs
@@ -150,7 +150,9 @@ impl<const B: bool> Precompile for Keccak256Precompile<B> {
                 };
 
                 let enough_buffer_space = input_buffer.can_fill_bytes(meaningful_bytes_in_query);
-                let should_read = paddings_round == false && enough_buffer_space;
+                let nothing_to_read = meaningful_bytes_in_query == 0;
+                let should_read =
+                    nothing_to_read == false && paddings_round == false && enough_buffer_space;
 
                 let bytes_to_fill = if should_read {
                     meaningful_bytes_in_query


### PR DESCRIPTION
# What ❔

We do not need to repeat read queries when full input is already read

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
